### PR TITLE
Song of the Day — implementation plan

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,3 +2,12 @@ CONTENTFUL_SPACE_ID=
 CONTENTFUL_ACCESS_TOKEN=
 CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 CONTENTFUL_PREVIEW_SECRET=
+
+# Song of the Day
+# Supabase project: nick-hess-dev-songs
+SUPABASE_URL=https://wyciyuadlbmhaukbvfcl.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=
+# Bearer token required to POST a new song to /api/song
+SONG_API_SECRET=
+# Bearer token used by the daily Vercel cron that backfills null entries
+CRON_SECRET=

--- a/.env.local.example
+++ b/.env.local.example
@@ -4,10 +4,8 @@ CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 CONTENTFUL_PREVIEW_SECRET=
 
 # Song of the Day
-# In deployed environments these two are injected automatically by the Vercel
-# Supabase integration. For local dev, copy them from the Supabase dashboard
-# (Project Settings -> API) for your "Song of the Day" project.
-SUPABASE_URL=
+# Supabase project: nick-hess-dev-songs
+SUPABASE_URL=https://wyciyuadlbmhaukbvfcl.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=
 # Bearer token required to POST a new song to /api/song
 SONG_API_SECRET=

--- a/.env.local.example
+++ b/.env.local.example
@@ -4,8 +4,10 @@ CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 CONTENTFUL_PREVIEW_SECRET=
 
 # Song of the Day
-# Supabase project: nick-hess-dev-songs
-SUPABASE_URL=https://wyciyuadlbmhaukbvfcl.supabase.co
+# In deployed environments these two are injected automatically by the Vercel
+# Supabase integration. For local dev, copy them from the Supabase dashboard
+# (Project Settings -> API) for your "Song of the Day" project.
+SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 # Bearer token required to POST a new song to /api/song
 SONG_API_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ session-*.md
 .now
 .vercel
 .env*.local
+
+# TypeScript incremental build info
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Single-page personal resume site built with Next.js 16 (App Router), React 19, a
 
 **Deployment:** Vercel (project config in `.vercel/project.json`). Analytics via `@vercel/analytics`.
 
+**Song of the Day** (`/song`): The one piece of dynamic, database-backed content. A song is posted via `POST /api/song` (bearer-auth with `SONG_API_SECRET`) with an Apple Music link; the track id is parsed (`lib/appleMusic.ts`) and metadata resolved via the free iTunes Lookup API, then upserted into a Supabase Postgres table (`songs_of_the_day`, one row per day keyed on `date`). All DB access goes through a server-only service-role client (`lib/supabase.ts`, lazily created) via the query layer in `lib/songs.ts`. The page shows today's song (America/Denver), or a random past "throwback" when today is unset. A daily Vercel cron (`vercel.json` → `/api/song/backfill`, auth via `CRON_SECRET`) records null entries for past dates that never got a song. Rich OG/Twitter share tags are generated per-day in the page's `generateMetadata`. Requires env vars `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SONG_API_SECRET`, `CRON_SECRET` (see `.env.local.example`).
+
 ## Conventions
 
 - Single quotes (`.prettierrc`)

--- a/app/api/song/backfill/route.ts
+++ b/app/api/song/backfill/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { backfillNullEntries } from '@/lib/songs';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Records null entries for any past date that never got a song. Invoked daily by
+ * the Vercel cron defined in vercel.json. Vercel cron requests carry the
+ * `Authorization: Bearer $CRON_SECRET` header automatically.
+ */
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const created = await backfillNullEntries();
+    return NextResponse.json({ created });
+  } catch (err) {
+    console.error('Backfill failed', err);
+    return NextResponse.json({ error: 'Backfill failed' }, { status: 500 });
+  }
+}

--- a/app/api/song/route.ts
+++ b/app/api/song/route.ts
@@ -78,6 +78,23 @@ export async function GET() {
     return NextResponse.json(resolved ?? { song: null });
   } catch (err) {
     console.error('Failed to resolve song', err);
-    return NextResponse.json({ error: 'Failed to resolve song' }, { status: 500 });
+    // TEMP DIAGNOSTIC: surface the cause and which env vars are present
+    // (booleans only — no secret values). Remove before merge.
+    return NextResponse.json(
+      {
+        error: 'Failed to resolve song',
+        detail: err instanceof Error ? err.message : String(err),
+        env: {
+          SUPABASE_URL: Boolean(process.env.SUPABASE_URL),
+          NEXT_PUBLIC_SUPABASE_URL: Boolean(
+            process.env.NEXT_PUBLIC_SUPABASE_URL
+          ),
+          SUPABASE_SERVICE_ROLE_KEY: Boolean(
+            process.env.SUPABASE_SERVICE_ROLE_KEY
+          ),
+        },
+      },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/song/route.ts
+++ b/app/api/song/route.ts
@@ -78,23 +78,6 @@ export async function GET() {
     return NextResponse.json(resolved ?? { song: null });
   } catch (err) {
     console.error('Failed to resolve song', err);
-    // TEMP DIAGNOSTIC: surface the cause and which env vars are present
-    // (booleans only — no secret values). Remove before merge.
-    return NextResponse.json(
-      {
-        error: 'Failed to resolve song',
-        detail: err instanceof Error ? err.message : String(err),
-        env: {
-          SUPABASE_URL: Boolean(process.env.SUPABASE_URL),
-          NEXT_PUBLIC_SUPABASE_URL: Boolean(
-            process.env.NEXT_PUBLIC_SUPABASE_URL
-          ),
-          SUPABASE_SERVICE_ROLE_KEY: Boolean(
-            process.env.SUPABASE_SERVICE_ROLE_KEY
-          ),
-        },
-      },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to resolve song' }, { status: 500 });
   }
 }

--- a/app/api/song/route.ts
+++ b/app/api/song/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { extractTrackId, lookupTrack } from '@/lib/appleMusic';
+import {
+  resolveDisplaySong,
+  todayInDenver,
+  upsertSong,
+} from '@/lib/songs';
+
+export const dynamic = 'force-dynamic';
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.SONG_API_SECRET;
+  if (!secret) return false;
+  const header = request.headers.get('authorization');
+  return header === `Bearer ${secret}`;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { url?: unknown; date?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body.url !== 'string' || body.url.trim() === '') {
+    return NextResponse.json(
+      { error: 'Missing required field: url' },
+      { status: 400 }
+    );
+  }
+
+  let date = todayInDenver();
+  if (body.date !== undefined) {
+    if (typeof body.date !== 'string' || !DATE_RE.test(body.date)) {
+      return NextResponse.json(
+        { error: 'date must be in YYYY-MM-DD format' },
+        { status: 400 }
+      );
+    }
+    date = body.date;
+  }
+
+  const trackId = extractTrackId(body.url);
+  if (!trackId) {
+    return NextResponse.json(
+      { error: 'Could not parse an Apple Music track id from the url' },
+      { status: 400 }
+    );
+  }
+
+  const meta = await lookupTrack(trackId);
+  if (!meta) {
+    return NextResponse.json(
+      { error: 'Could not resolve track metadata from Apple Music' },
+      { status: 502 }
+    );
+  }
+
+  try {
+    const song = await upsertSong(date, meta, body.url.trim());
+    return NextResponse.json({ song }, { status: 200 });
+  } catch (err) {
+    console.error('Failed to save song', err);
+    return NextResponse.json({ error: 'Failed to save song' }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  try {
+    const resolved = await resolveDisplaySong();
+    return NextResponse.json(resolved ?? { song: null });
+  } catch (err) {
+    console.error('Failed to resolve song', err);
+    return NextResponse.json({ error: 'Failed to resolve song' }, { status: 500 });
+  }
+}

--- a/app/song/page.tsx
+++ b/app/song/page.tsx
@@ -1,0 +1,116 @@
+import { cache } from 'react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import ThemeToggle from '@/components/ThemeToggle';
+import SongCard from '@/components/SongCard';
+import { resolveDisplaySong } from '@/lib/songs';
+
+export const dynamic = 'force-dynamic';
+
+// Cached per-request so generateMetadata and the page share one resolution
+// (and the same random fallback pick).
+const getResolved = cache(resolveDisplaySong);
+
+const PAGE_URL = 'https://nickhess.dev/song';
+
+export async function generateMetadata(): Promise<Metadata> {
+  let resolved;
+  try {
+    resolved = await getResolved();
+  } catch {
+    resolved = null;
+  }
+
+  if (!resolved) {
+    return {
+      title: 'Song of the Day — Nick Hess',
+      description: 'Nick Hess’s favorite song of the day.',
+      alternates: { canonical: PAGE_URL },
+    };
+  }
+
+  const { song } = resolved;
+  const title = `${song.title} — ${song.artist}`;
+  const description = song.album
+    ? `${song.title} by ${song.artist} (${song.album}) — Nick Hess’s song of the day.`
+    : `${song.title} by ${song.artist} — Nick Hess’s song of the day.`;
+
+  const images = song.artwork_url
+    ? [
+        {
+          url: song.artwork_url,
+          width: 1200,
+          height: 1200,
+          alt: `${song.title} by ${song.artist}`,
+        },
+      ]
+    : undefined;
+
+  return {
+    title: `${title} · Song of the Day`,
+    description,
+    alternates: { canonical: PAGE_URL },
+    openGraph: {
+      title,
+      description,
+      url: PAGE_URL,
+      siteName: 'Nick Hess',
+      type: 'music.song',
+      images,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: song.artwork_url ? [song.artwork_url] : undefined,
+      creator: '@nickdhess',
+      site: '@nickdhess',
+    },
+    other: {
+      ...(song.artist ? { 'music:musician': song.artist } : {}),
+      ...(song.album ? { 'music:album': song.album } : {}),
+    },
+  };
+}
+
+export default async function SongPage() {
+  const resolved = await getResolved();
+
+  return (
+    <main className="max-w-2xl mx-auto px-5 sm:px-8 py-12 sm:py-16 space-y-10 relative">
+      <div className="absolute top-4 right-4 sm:top-6 sm:right-6 no-print">
+        <ThemeToggle />
+      </div>
+
+      <header className="animate-in">
+        <h1 className="font-[family-name:var(--font-display)] text-5xl sm:text-6xl md:text-7xl font-[160] tracking-tight leading-none mb-3">
+          Song of the Day
+        </h1>
+        <Link
+          href="/"
+          className="text-sm text-accent hover:underline underline-offset-4 transition-colors"
+        >
+          &larr; Back to Nick Hess
+        </Link>
+      </header>
+
+      {resolved ? (
+        <SongCard resolved={resolved} />
+      ) : (
+        <section className="animate-in delay-1">
+          <div className="border border-border rounded-lg px-5 py-4 bg-highlight/40">
+            <p className="text-sm text-ink-muted">
+              No song has been posted yet. Check back soon.
+            </p>
+          </div>
+        </section>
+      )}
+
+      <footer className="animate-in delay-2 pt-6 border-t border-border-faint">
+        <p className="text-xs text-ink-faint">
+          &copy; {new Date().getFullYear()} Nick Hess
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/components/SongCard.tsx
+++ b/components/SongCard.tsx
@@ -1,0 +1,78 @@
+import type { ResolvedSong } from '@/lib/songs';
+
+const TIME_ZONE = 'America/Denver';
+
+function formatLongDate(date: string): string {
+  // Parse as UTC noon to avoid the date shifting under timezone formatting.
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: TIME_ZONE,
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(`${date}T12:00:00Z`));
+}
+
+export default function SongCard({ resolved }: { resolved: ResolvedSong }) {
+  const { song, isFallback, forDate } = resolved;
+
+  return (
+    <section className="animate-in delay-1">
+      <p className="text-sm text-ink-muted mb-4">
+        {isFallback ? (
+          <>
+            No pick yet for {formatLongDate(forDate)} — here&rsquo;s a throwback
+            from {formatLongDate(song.date)}.
+          </>
+        ) : (
+          <>Song of the day · {formatLongDate(forDate)}</>
+        )}
+      </p>
+
+      <div className="border border-border rounded-lg p-5 bg-highlight/40">
+        <div className="flex flex-col sm:flex-row gap-5">
+          {song.artwork_url && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={song.artwork_url}
+              alt={`${song.title} by ${song.artist} album artwork`}
+              width={160}
+              height={160}
+              className="w-40 h-40 rounded-lg shrink-0 shadow-sm object-cover"
+            />
+          )}
+
+          <div className="min-w-0 flex flex-col">
+            {isFallback && (
+              <span className="self-start mb-2 inline-block rounded-full bg-accent-subtle px-2.5 py-0.5 text-xs font-medium text-accent">
+                Throwback
+              </span>
+            )}
+
+            <h2 className="font-[family-name:var(--font-display)] text-3xl sm:text-4xl font-[160] tracking-tight leading-tight">
+              {song.title}
+            </h2>
+            <p className="text-base text-ink-muted mt-1">{song.artist}</p>
+
+            {song.album && (
+              <p className="text-sm text-ink-faint mt-0.5">{song.album}</p>
+            )}
+            {song.genre && (
+              <p className="text-sm text-ink-faint mt-0.5">{song.genre}</p>
+            )}
+
+            {song.apple_music_url && (
+              <a
+                href={song.apple_music_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center self-start mt-4 text-sm font-medium text-accent hover:underline underline-offset-4"
+              >
+                Listen on Apple Music &rarr;
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/song-of-the-day-plan.md
+++ b/docs/song-of-the-day-plan.md
@@ -1,0 +1,126 @@
+# Song of the Day — Implementation Plan
+
+A new page on the site that tracks Nick's favorite song of the day. Songs are
+posted via an authenticated API endpoint using an Apple Music link, persisted to
+a database, and rendered on a page with rich social-share meta tags.
+
+## Decisions
+
+- **Storage:** A new dedicated Supabase Postgres project, with one row per
+  calendar day.
+- **Page behavior:** Show today's song. If today has no song set yet, show a
+  random past song as a "throwback" fallback until one is posted. Dates that are
+  never set get a persisted `null` entry.
+- **Metadata source:** The free iTunes Lookup API (no auth) resolves title,
+  artist, album, artwork, and preview from an Apple Music link.
+- **Timezone:** America/Denver — "today" is computed in Nick's local day, not
+  UTC.
+- **No embedded player** — artwork, text, and a "Listen on Apple Music" link
+  only.
+
+## Architecture overview
+
+```
+POST /api/song          ──▶ parse Apple Music URL ──▶ iTunes Lookup ──▶ upsert songs(date)
+GET  /song              ──▶ resolve today's song (or random fallback) ──▶ render + OG/Twitter tags
+GET  /api/song/backfill ──▶ (Vercel Cron, ~00:05 MT) insert null rows for any missed dates
+```
+
+## 0. New Supabase project
+
+Create a fresh project in the existing **F1 Fantasy** org (`us-west-1`, to match
+the existing project) named e.g. `nick-hess-dev-songs`. Creating a project is a
+paid org resource, so the Supabase MCP will require a cost confirmation to be
+approved at build time. Once provisioned, grab the project URL and service-role
+key for env vars.
+
+## 1. Database
+
+Migration applied via the Supabase MCP `apply_migration`:
+
+```sql
+create table public.songs_of_the_day (
+  date            date primary key,
+  apple_music_url text,
+  track_id        text,
+  title           text,
+  artist          text,
+  album           text,
+  artwork_url     text,        -- upscaled to 1200x1200
+  preview_url     text,
+  genre           text,
+  is_null_entry   boolean not null default false,  -- true = "no song this day"
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+alter table public.songs_of_the_day enable row level security;
+-- No public policies: all access is server-side via the service-role key.
+```
+
+A "null entry" is a row with `is_null_entry = true` and null song fields.
+
+## 2. Dependencies & env vars
+
+- Add `@supabase/supabase-js`.
+- New env vars (added to `.env.local.example` and the Vercel project):
+  - `SUPABASE_URL`
+  - `SUPABASE_SERVICE_ROLE_KEY` (server-only, never client-exposed)
+  - `SONG_API_SECRET` — bearer token guarding the POST endpoint
+  - `CRON_SECRET` — guards the backfill route
+
+## 3. New files
+
+- **`lib/supabase.ts`** — server-only Supabase client (service role).
+- **`lib/appleMusic.ts`**
+  - `extractTrackId(url)` — handles both `…/song/name/123` and
+    `…/album/name/456?i=123` forms (the `i` param is the track id when present).
+  - `lookupTrack(trackId)` — calls
+    `https://itunes.apple.com/lookup?id=<id>`, maps `trackName`, `artistName`,
+    `collectionName`, `artworkUrl100`, `previewUrl`, `primaryGenreName`;
+    upscales artwork (`100x100` → `1200x1200bb`).
+- **`lib/songs.ts`** — DB queries: `getSongForDate(date)`,
+  `getRandomSetSong()`, `upsertSong(date, data)`, `ensureRowExists(date)`,
+  `backfillNullEntries()`.
+- **`app/api/song/route.ts`**
+  - `POST`: checks `Authorization: Bearer $SONG_API_SECRET`; body
+    `{ url: string, date?: string }` (defaults to today/MT). Parses URL →
+    lookup → upsert. Returns the stored song as JSON (400 on bad URL, 401 on bad
+    auth, 502 if lookup fails).
+  - `GET` (optional): returns today's resolved song as JSON.
+- **`app/api/song/backfill/route.ts`** — cron target (guarded by `CRON_SECRET`):
+  inserts `is_null_entry` rows for any date between the first entry and yesterday
+  that has no row. Belt-and-suspenders with lazy creation on read.
+- **`app/song/page.tsx`** — Server Component, `export const dynamic = 'force-dynamic'`:
+  - Resolve today (MT). If a real song exists → show it (canonical). If
+    missing/null → render a random past song marked as a "throwback" fallback,
+    and lazily ensure today's row exists.
+  - `generateMetadata()` builds rich tags from the resolved song: `title`,
+    `description` (`"<title> — <artist>"`), `openGraph` (`type: 'music.song'`,
+    square artwork as the image with width + height, `music:musician` /
+    `music:album` via the `other` field), and `twitter`
+    (`summary_large_image`). One canonical URL (`/song`) whose tags reflect the
+    current day, so any social network gets the right preview.
+- **`app/song/SongCard.tsx`** (+ small subcomponents) — artwork, title, artist,
+  album, "Listen on Apple Music" link, and a subtle "throwback" badge when
+  showing a fallback. Uses existing semantic tokens (`--color-surface`,
+  `--color-ink`, etc.) and `.animate-in` stagger classes — no `dark:` variants,
+  matching CLAUDE.md conventions.
+- **`vercel.json`** — daily cron hitting `/api/song/backfill`.
+
+## 4. Posting a song
+
+```bash
+curl -X POST https://nickhess.dev/api/song \
+  -H "Authorization: Bearer $SONG_API_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://music.apple.com/us/album/x/123?i=456"}'
+```
+
+(Easy to wire into an iOS Shortcut later for one-tap posting from the Music
+app's share sheet.)
+
+## 5. Verification
+
+- `pnpm type-check` and `pnpm lint`.
+- Local test: POST a real Apple Music link, load `/song`, confirm
+  artwork/metadata and OG tags (via view-source / a card validator).

--- a/lib/appleMusic.ts
+++ b/lib/appleMusic.ts
@@ -1,0 +1,110 @@
+export type TrackMetadata = {
+  trackId: string;
+  title: string;
+  artist: string;
+  album: string | null;
+  artworkUrl: string | null;
+  previewUrl: string | null;
+  genre: string | null;
+};
+
+/**
+ * Extracts the numeric track id from an Apple Music URL.
+ *
+ * Handles the two common shapes:
+ *   - Album/playlist link with a track: .../album/name/123456?i=789012  → 789012
+ *   - Direct song link:                 .../song/name/123456           → 123456
+ */
+export function extractTrackId(rawUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl.trim());
+  } catch {
+    return null;
+  }
+
+  if (!/(^|\.)music\.apple\.com$/.test(parsed.hostname)) {
+    return null;
+  }
+
+  // A track inside an album/playlist link is carried by the `i` query param.
+  const iParam = parsed.searchParams.get('i');
+  if (iParam && /^\d+$/.test(iParam)) {
+    return iParam;
+  }
+
+  // A direct /song/ link carries the id as the last path segment.
+  if (parsed.pathname.includes('/song/')) {
+    const lastSegment = parsed.pathname.split('/').filter(Boolean).pop();
+    if (lastSegment && /^\d+$/.test(lastSegment)) {
+      return lastSegment;
+    }
+  }
+
+  return null;
+}
+
+type ItunesResult = {
+  wrapperType?: string;
+  kind?: string;
+  trackName?: string;
+  artistName?: string;
+  collectionName?: string;
+  artworkUrl100?: string;
+  previewUrl?: string;
+  primaryGenreName?: string;
+};
+
+/** Upscales the default 100x100 iTunes artwork URL to a share-friendly size. */
+function upscaleArtwork(url: string | undefined): string | null {
+  if (!url) return null;
+  return url.replace(/\/\d+x\d+(bb)?\.jpg$/, '/1200x1200bb.jpg');
+}
+
+/**
+ * Looks up track metadata via the public iTunes Lookup API (no auth required).
+ * Returns null if the id resolves to nothing or the request fails.
+ */
+export async function lookupTrack(
+  trackId: string
+): Promise<TrackMetadata | null> {
+  const endpoint = `https://itunes.apple.com/lookup?id=${encodeURIComponent(
+    trackId
+  )}&entity=song`;
+
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+  } catch {
+    return null;
+  }
+
+  if (!res.ok) return null;
+
+  let data: { resultCount?: number; results?: ItunesResult[] };
+  try {
+    data = await res.json();
+  } catch {
+    return null;
+  }
+
+  const result = data.results?.find(
+    (r) => r.kind === 'song' || r.wrapperType === 'track'
+  );
+  if (!result || !result.trackName || !result.artistName) {
+    return null;
+  }
+
+  return {
+    trackId,
+    title: result.trackName,
+    artist: result.artistName,
+    album: result.collectionName ?? null,
+    artworkUrl: upscaleArtwork(result.artworkUrl100),
+    previewUrl: result.previewUrl ?? null,
+    genre: result.primaryGenreName ?? null,
+  };
+}

--- a/lib/songs.ts
+++ b/lib/songs.ts
@@ -1,0 +1,176 @@
+import 'server-only';
+import { getSupabase } from './supabase';
+import type { TrackMetadata } from './appleMusic';
+
+const TABLE = 'songs_of_the_day';
+const TIME_ZONE = 'America/Denver';
+
+export type Song = {
+  date: string;
+  apple_music_url: string | null;
+  track_id: string | null;
+  title: string | null;
+  artist: string | null;
+  album: string | null;
+  artwork_url: string | null;
+  preview_url: string | null;
+  genre: string | null;
+  is_null_entry: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+/** A row that actually has a song (title present, not a null entry). */
+export type SetSong = Song & { title: string; artist: string };
+
+export function isSetSong(song: Song | null | undefined): song is SetSong {
+  return Boolean(song && !song.is_null_entry && song.title && song.artist);
+}
+
+/** Current calendar date in America/Denver, formatted as YYYY-MM-DD. */
+export function todayInDenver(): string {
+  return formatDenverDate(new Date());
+}
+
+function formatDenverDate(date: Date): string {
+  // en-CA renders as YYYY-MM-DD, which is exactly the shape Postgres `date` wants.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+export type ResolvedSong = {
+  song: SetSong;
+  isFallback: boolean;
+  /** The date the page is for (today, MT) — may differ from song.date on fallback. */
+  forDate: string;
+};
+
+/**
+ * Resolves what to show on the page for today:
+ *   - today's song if one is set, otherwise
+ *   - a random past song flagged as a fallback ("throwback"), otherwise
+ *   - null when nothing has ever been posted.
+ *
+ * Today is intentionally left without a row when unset so it can still receive a
+ * song later; the backfill cron records null entries for past missed dates.
+ */
+export async function resolveDisplaySong(): Promise<ResolvedSong | null> {
+  const forDate = todayInDenver();
+  const todayRow = await getSongForDate(forDate);
+
+  if (isSetSong(todayRow)) {
+    return { song: todayRow, isFallback: false, forDate };
+  }
+
+  const fallback = await getRandomSetSong();
+  if (fallback) {
+    return { song: fallback, isFallback: true, forDate };
+  }
+
+  return null;
+}
+
+export async function getSongForDate(date: string): Promise<Song | null> {
+  const { data, error } = await getSupabase()
+    .from(TABLE)
+    .select('*')
+    .eq('date', date)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Returns a random previously-set song, used as a "throwback" fallback when the
+ * current day has no song yet. The dataset is one row per day, so fetching the
+ * set rows and picking in memory is cheap and avoids a custom RPC.
+ */
+export async function getRandomSetSong(): Promise<SetSong | null> {
+  const { data, error } = await getSupabase()
+    .from(TABLE)
+    .select('*')
+    .eq('is_null_entry', false)
+    .not('title', 'is', null);
+
+  if (error) throw error;
+  if (!data || data.length === 0) return null;
+
+  const pick = data[Math.floor(Math.random() * data.length)];
+  return isSetSong(pick) ? pick : null;
+}
+
+/** Inserts or updates the song for a given day. */
+export async function upsertSong(
+  date: string,
+  meta: TrackMetadata,
+  appleMusicUrl: string
+): Promise<Song> {
+  const { data, error } = await getSupabase()
+    .from(TABLE)
+    .upsert(
+      {
+        date,
+        apple_music_url: appleMusicUrl,
+        track_id: meta.trackId,
+        title: meta.title,
+        artist: meta.artist,
+        album: meta.album,
+        artwork_url: meta.artworkUrl,
+        preview_url: meta.previewUrl,
+        genre: meta.genre,
+        is_null_entry: false,
+      },
+      { onConflict: 'date' }
+    )
+    .select('*')
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Walks from the earliest recorded date up to (and including) yesterday and
+ * inserts a null entry for any date with no row. No-op until the first song
+ * has been posted.
+ */
+export async function backfillNullEntries(): Promise<number> {
+  const { data, error } = await getSupabase()
+    .from(TABLE)
+    .select('date')
+    .order('date', { ascending: true });
+
+  if (error) throw error;
+  if (!data || data.length === 0) return 0;
+
+  const existing = new Set(data.map((row) => row.date));
+  const start = new Date(`${data[0].date}T00:00:00Z`);
+  const today = todayInDenver();
+
+  const missing: { date: string; is_null_entry: true }[] = [];
+  for (
+    let d = new Date(start);
+    formatUtcDate(d) < today; // stop before today; today may still get a song
+    d.setUTCDate(d.getUTCDate() + 1)
+  ) {
+    const iso = formatUtcDate(d);
+    if (!existing.has(iso)) {
+      missing.push({ date: iso, is_null_entry: true });
+    }
+  }
+
+  if (missing.length === 0) return 0;
+
+  const { error: insertError } = await getSupabase().from(TABLE).insert(missing);
+  if (insertError) throw insertError;
+  return missing.length;
+}
+
+function formatUtcDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -14,12 +14,14 @@ let client: SupabaseClient | null = null;
 export function getSupabase(): SupabaseClient {
   if (client) return client;
 
-  const url = process.env.SUPABASE_URL;
+  // The Supabase Vercel connector injects the URL as SUPABASE_URL on some
+  // versions and NEXT_PUBLIC_SUPABASE_URL on others; accept either.
+  const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url || !serviceRoleKey) {
     throw new Error(
-      'Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.'
+      'Missing Supabase URL (SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL) or SUPABASE_SERVICE_ROLE_KEY environment variables.'
     );
   }
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,30 @@
+import 'server-only';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let client: SupabaseClient | null = null;
+
+/**
+ * Lazily creates a server-only Supabase client using the service-role key. The
+ * table has RLS enabled with no public policies, so all access flows through
+ * this privileged client, which must never be imported into client components.
+ *
+ * Created on first use (not at module load) so the build doesn't fail when env
+ * vars are absent during static analysis.
+ */
+export function getSupabase(): SupabaseClient {
+  if (client) return client;
+
+  const url = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error(
+      'Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.'
+    );
+  }
+
+  client = createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return client;
+}

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.108.2",
     "@vercel/analytics": "^1",
     "next": "^16.2.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "server-only": "^0.0.1",
     "tailwindcss": "^4"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.108.2
+        version: 2.108.2
       '@vercel/analytics':
         specifier: ^1
         version: 1.6.1(next@16.2.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -23,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -82,89 +88,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -225,24 +247,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.5':
     resolution: {integrity: sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.5':
     resolution: {integrity: sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.5':
     resolution: {integrity: sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.5':
     resolution: {integrity: sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==}
@@ -255,6 +281,33 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.3':
+    resolution: {integrity: sha512-jZL/2uPEiK58RFJ+7rctex60AHTdtVWwqw4cqu+5JGrXdu/ZM7ZwttO+yRsRN/E/Xik6s+tmbvH7XAQux4m9nQ==}
+
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
+    engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -297,24 +350,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -409,6 +466,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -448,24 +509,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -535,6 +600,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -726,6 +794,38 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.5':
     optional: true
 
+  '@supabase/auth-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.3': {}
+
+  '@supabase/postgrest-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.108.2':
+    dependencies:
+      '@supabase/phoenix': 0.4.3
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.108.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.108.2':
+    dependencies:
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -833,6 +933,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  iceberg-js@0.8.1: {}
+
   jiti@2.6.1: {}
 
   lightningcss-android-arm64@1.31.1:
@@ -933,6 +1035,8 @@ snapshots:
 
   semver@7.7.4:
     optional: true
+
+  server-only@0.0.1: {}
 
   sharp@0.34.5:
     dependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/song/backfill",
+      "schedule": "0 8 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the implementation plan for a **Song of the Day** feature: a page that tracks Nick's favorite song of the day, posted via an authenticated API endpoint using an Apple Music link, with rich social-share meta tags.

This PR contains the plan doc only (`docs/song-of-the-day-plan.md`) so changes can be reviewed and iterated on via Vercel deploy previews before the feature itself lands.

### Plan highlights
- **Storage:** new dedicated Supabase Postgres project, one row per calendar day
- **Page (`/song`):** shows today's song; falls back to a random past "throwback" if today isn't set yet; never-set dates get a persisted null entry
- **Write API (`POST /api/song`):** bearer-auth, takes an Apple Music link, resolves metadata via the free iTunes Lookup API, upserts the day's row
- **Backfill cron:** fills null entries for missed dates
- **Rich meta tags:** OG (`music.song` + artwork) and Twitter `summary_large_image` via `generateMetadata()`
- **Timezone:** America/Denver

### Next steps (follow-up commits on this branch)
1. Create the Supabase project + table
2. Add the API routes, lib helpers, and `/song` page
3. Wire env vars and the Vercel cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs5CVbeWEHsAqHiE1tdG4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs5CVbeWEHsAqHiE1tdG4c)_